### PR TITLE
add one more step to open mysql console as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 1. `sudo apt update`
 2. `sudo apt install mysql-server`
 3. `sudo systemctl status mysql` - Make sure the *Active* status is *active (running)*
-4. `CREATE USER '<username>'@'localhost' IDENTIFIED BY '<password>';`
-5. `GRANT ALL PRIVILEGES ON hooligram.* TO '<username>'@'localhost' IDENTIFIED BY '<password>';`
-6. `CREATE DATABASE hooligram;`
+4. `sudo mysql #opens mysql console as root`
+5. `CREATE USER '<username>'@'localhost' IDENTIFIED BY '<password>';`
+6. `GRANT ALL PRIVILEGES ON hooligram.* TO '<username>'@'localhost' IDENTIFIED BY '<password>';`
+7. `CREATE DATABASE hooligram;`
+


### PR DESCRIPTION
Adds one more step in the mysql setup instructions to open mysql console as root #12 

...
3. sudo systemctl status mysql
4. sudo mysql #open mysql console as root
5. CREATE USER '<username>'@'localhost' IDENTIFIED BY '<password>';
...