### PR TITLE
support message groups

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -9,6 +9,10 @@ const (
 	messagingBroadcastRequest = "MESSAGING_BROADCAST_REQUEST"
 	messagingBroadcastSuccess = "MESSAGING_BROADCAST_SUCCESS"
 
+	messagingDeliverFailure = "MESSAGING_DELIVER_FAILURE"
+	messagingDeliverRequest = "MESSAGING_DELIVER_REQUEST"
+	messagingDeliverSuccess = "MESSAGING_DELIVER_SUCCESS"
+
 	messagingSendFailure = "MESSAGING_SEND_FAILURE"
 	messagingSendRequest = "MESSAGING_SEND_REQUEST"
 	messagingSendSuccess = "MESSAGING_SEND_SUCCESS"

--- a/constants.go
+++ b/constants.go
@@ -9,6 +9,10 @@ const (
 	messagingBroadcastRequest = "MESSAGING_BROADCAST_REQUEST"
 	messagingBroadcastSuccess = "MESSAGING_BROADCAST_SUCCESS"
 
+	messagingSendFailure = "MESSAGING_SEND_FAILURE"
+	messagingSendRequest = "MESSAGING_SEND_REQUEST"
+	messagingSendSuccess = "MESSAGING_SEND_SUCCESS"
+
 	verificationRequestCodeFailure = "VERIFICATION_REQUEST_CODE_FAILURE"
 	verificationRequestCodeRequest = "VERIFICATION_REQUEST_CODE_REQUEST"
 	verificationRequestCodeSuccess = "VERIFICATION_REQUEST_CODE_SUCCESS"

--- a/db.go
+++ b/db.go
@@ -44,12 +44,70 @@ func init() {
 	db.Exec(`
 		CREATE TABLE IF NOT EXISTS client (
 			id INT UNSIGNED NOT NULL AUTO_INCREMENT,
-			country_code VARCHAR (50) NOT NULL,
-			phone_number VARCHAR (50) NOT NULL,
-			verification_code VARCHAR (50),
+			country_code VARCHAR (64) NOT NULL,
+			phone_number VARCHAR (64) NOT NULL,
+			verification_code VARCHAR (64),
+			date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (id),
 			UNIQUE KEY (country_code, phone_number)
-		)
+		);
+	`)
+
+	db.Exec(`
+		CREATE TABLE IF NOT EXISTS message_group (
+			id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+			name VARCHAR (32) NOT NULL,
+			date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id)
+		);
+	`)
+
+	db.Exec(`
+		CREATE TABLE IF NOT EXISTS message (
+			id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+			content TEXT NOT NULL,
+			message_group_id INT UNSIGNED NOT NULL,
+			sender_id INT UNSIGNED NOT NULL,
+			date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			CONSTRAINT FOREIGN KEY (message_group_id) REFERENCES message_group (id)
+				ON DELETE CASCADE
+				ON UPDATE CASCADE,
+			CONSTRAINT FOREIGN KEY (sender_id) REFERENCES client (id)
+				ON DELETE CASCADE
+				ON UPDATE CASCADE
+		);
+	`)
+
+	db.Exec(`
+		CREATE TABLE IF NOT EXISTS message_group_member (
+			message_group_id INT UNSIGNED NOT NULL,
+			member_id INT UNSIGNED NOT NULL,
+			date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (message_group_id, member_id),
+			CONSTRAINT FOREIGN KEY (message_group_id) REFERENCES message_group (id)
+				ON DELETE CASCADE
+				ON UPDATE CASCADE,
+			CONSTRAINT FOREIGN KEY (member_id) REFERENCES client (id)
+				ON DELETE CASCADE
+				ON UPDATE CASCADE
+		);
+	`)
+
+	db.Exec(`
+		CREATE TABLE IF NOT EXISTS receipt (
+			message_id INT UNSIGNED NOT NULL,
+			recipient_id INT UNSIGNED NOT NULL,
+			date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+			date_delivered DATETIME,
+			PRIMARY KEY (message_id, recipient_id),
+			CONSTRAINT FOREIGN KEY (message_id) REFERENCES message (id)
+				ON DELETE CASCADE
+				ON UPDATE CASCADE,
+			CONSTRAINT FOREIGN KEY (recipient_id) REFERENCES client (id)
+				ON DELETE CASCADE
+				ON UPDATE CASCADE
+		);
 	`)
 }
 

--- a/db.go
+++ b/db.go
@@ -141,6 +141,14 @@ func createMessage(content string, messageGroupID, senderID int) (*Message, erro
 	}, nil
 }
 
+func createReceipt(messageID, recipientID int) error {
+	_, err := db.Query(`
+		INSERT INTO receipt (message_id, recipient_id) VALUES (?, ?);
+	`, messageID, recipientID)
+
+	return err
+}
+
 func getOrCreateClient(countryCode, phoneNumber string) (*Client, error) {
 	if countryCode != getDigits(countryCode) {
 		return nil, errors.New("hey, countryCode should only contain digits")
@@ -171,6 +179,27 @@ func getOrCreateClient(countryCode, phoneNumber string) (*Client, error) {
 	}
 
 	return client, nil
+}
+
+func findAllMessageGroupMemberIDs(messageGroupID int) ([]int, error) {
+	rows, err := db.Query(`
+		SELECT member_id
+		FROM message_group_member
+		WHERE message_group_id = ?;
+	`, messageGroupID)
+	if err != nil {
+		return nil, err
+	}
+
+	var memberIDs []int
+
+	for rows.Next() {
+		var id int
+		rows.Scan(&id)
+		memberIDs = append(memberIDs, id)
+	}
+
+	return memberIDs, nil
 }
 
 func findAllVerifiedClients() []*Client {

--- a/db.go
+++ b/db.go
@@ -161,12 +161,14 @@ func findAllVerifiedClients() []*Client {
 		var countryCode string
 		var phoneNumber string
 		var verificationCode string
-		rows.Scan(&id, &countryCode, &phoneNumber, &verificationCode)
+		var dateCreated string
+		rows.Scan(&id, &countryCode, &phoneNumber, &verificationCode, &dateCreated)
 		client := Client{
 			ID:               id,
 			CountryCode:      countryCode,
 			PhoneNumber:      phoneNumber,
 			VerificationCode: verificationCode,
+			DateCreated:      dateCreated,
 		}
 		clients = append(clients, &client)
 	}
@@ -196,13 +198,15 @@ func findClient(countryCode, phoneNumber string) (*Client, bool) {
 
 	var id int
 	var verificationCode string
-	rows.Scan(&id, nil, nil, &verificationCode)
+	var dateCreated string
+	rows.Scan(&id, nil, nil, &verificationCode, &dateCreated)
 
 	client := &Client{
 		ID:               id,
 		CountryCode:      countryCode,
 		PhoneNumber:      phoneNumber,
 		VerificationCode: verificationCode,
+		DateCreated:      dateCreated,
 	}
 
 	return client, true
@@ -227,12 +231,14 @@ func findVerifiedClient(countryCode, phoneNumber, verificationCode string) (*Cli
 	}
 
 	var id int
-	rows.Scan(&id)
+	var dateCreated string
+	rows.Scan(&id, nil, nil, nil, &dateCreated)
 	client := Client{
 		ID:               id,
 		CountryCode:      countryCode,
 		PhoneNumber:      phoneNumber,
 		VerificationCode: verificationCode,
+		DateCreated:      dateCreated,
 	}
 
 	return &client, true

--- a/db.go
+++ b/db.go
@@ -129,6 +129,10 @@ func createMessage(content string, messageGroupID, senderID int) (*Message, erro
 		return nil, errors.New("failed to find message")
 	}
 
+	if !rows.Next() {
+		return nil, errors.New("can't find message")
+	}
+
 	var dateCreated string
 	rows.Scan(&dateCreated)
 

--- a/globals.go
+++ b/globals.go
@@ -12,6 +12,7 @@ var broadcastChan = make(chan *Action)
 var clients = make(map[*websocket.Conn]*Client)
 var db *sql.DB
 var httpClient = &http.Client{}
+var messageDeliveryChan = make(chan *MessageDelivery)
 var pendingActionQueue = make(map[*Client][]*Action)
 var twilioAPIKey string
 var upgrader = websocket.Upgrader{}

--- a/structs.go
+++ b/structs.go
@@ -21,3 +21,12 @@ type Client struct {
 	IsSignedIn bool
 	conn       *websocket.Conn
 }
+
+// Message .
+type Message struct {
+	ID             int
+	Content        string
+	MessageGroupID int
+	SenderID       int
+	DateCreated    string
+}

--- a/structs.go
+++ b/structs.go
@@ -30,3 +30,9 @@ type Message struct {
 	SenderID       int
 	DateCreated    string
 }
+
+// MessageDelivery .
+type MessageDelivery struct {
+	Message      *Message
+	RecipientIDs []int
+}

--- a/structs.go
+++ b/structs.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/gorilla/websocket"
+import (
+	"github.com/gorilla/websocket"
+)
 
 // Action .
 type Action struct {
@@ -14,6 +16,7 @@ type Client struct {
 	CountryCode      string
 	PhoneNumber      string
 	VerificationCode string
+	DateCreated      string
 
 	IsSignedIn bool
 	conn       *websocket.Conn

--- a/test.sql
+++ b/test.sql
@@ -1,0 +1,23 @@
+DELETE FROM client;
+INSERT INTO client (id, country_code, phone_number, verification_code) VALUES (1, 1, 1, 1);
+INSERT INTO client (id, country_code, phone_number, verification_code) VALUES (2, 2, 2, 2);
+INSERT INTO client (id, country_code, phone_number, verification_code) VALUES (3, 3, 3, 3);
+INSERT INTO client (id, country_code, phone_number, verification_code) VALUES (4, 4, 4, 4);
+INSERT INTO client (id, country_code, phone_number, verification_code) VALUES (5, 5, 5, 5);
+INSERT INTO client (id, country_code, phone_number, verification_code) VALUES (6, 6, 6, 6);
+INSERT INTO client (id, country_code, phone_number, verification_code) VALUES (7, 7, 7, 7);
+
+DELETE FROM message_group;
+INSERT INTO message_group (id, name) VALUES (1, "message group a (1, 2)");
+INSERT INTO message_group (id, name) VALUES (2, "message group b (1, 2, 3)");
+INSERT INTO message_group (id, name) VALUES (3, "message group c (3, 4, 5)");
+
+DELETE FROM message_group_member;
+INSERT INTO message_group_member (message_group_id, member_id) VALUES (1, 1);
+INSERT INTO message_group_member (message_group_id, member_id) VALUES (1, 2);
+INSERT INTO message_group_member (message_group_id, member_id) VALUES (2, 1);
+INSERT INTO message_group_member (message_group_id, member_id) VALUES (2, 2);
+INSERT INTO message_group_member (message_group_id, member_id) VALUES (2, 3);
+INSERT INTO message_group_member (message_group_id, member_id) VALUES (3, 3);
+INSERT INTO message_group_member (message_group_id, member_id) VALUES (3, 4);
+INSERT INTO message_group_member (message_group_id, member_id) VALUES (3, 5);

--- a/utils.go
+++ b/utils.go
@@ -6,11 +6,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func getDigits(s string) string {
-	re := regexp.MustCompile("[^0-9]")
-	return re.ReplaceAllString(s, "")
-}
-
 func constructBroadcastAction(source *Client, message string) *Action {
 	sender := make(map[string]string)
 	sender["country_code"] = source.CountryCode
@@ -24,6 +19,34 @@ func constructBroadcastAction(source *Client, message string) *Action {
 		Payload: payload,
 		Type:    messagingBroadcastSuccess,
 	}
+}
+
+func constructDeliverMessageAction(message *Message) *Action {
+	payload := make(map[string]interface{})
+	payload["content"] = message.Content
+	payload["date_created"] = message.DateCreated
+	payload["id"] = message.ID
+	payload["sender_id"] = message.SenderID
+
+	return &Action{
+		Payload: payload,
+		Type:    messagingDeliverRequest,
+	}
+}
+
+func containsID(ids []int, id int) bool {
+	for _, i := range ids {
+		if i == id {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getDigits(s string) string {
+	re := regexp.MustCompile("[^0-9]")
+	return re.ReplaceAllString(s, "")
 }
 
 func writeFailure(conn *websocket.Conn, actionType string, errors []string) {

--- a/v2.go
+++ b/v2.go
@@ -43,6 +43,8 @@ func v2(w http.ResponseWriter, r *http.Request) {
 		switch action.Type {
 		case authorizationSignInRequest:
 			handleAuthorizationSignInRequest(conn, &action)
+		case messagingSendRequest:
+			handleMessagingSendRequest(conn, &action)
 		case messagingBroadcastRequest:
 			handleMessagingBroadcastRequest(conn, &action)
 		case verificationRequestCodeRequest:
@@ -71,6 +73,55 @@ func handleAuthorizationSignInRequest(conn *websocket.Conn, action *Action) {
 	writeQueuedActions(client)
 	action.Type = authorizationSignInSuccess
 	client.writeJSON(action)
+}
+
+func handleMessagingSendRequest(conn *websocket.Conn, action *Action) {
+	client, err := getSignedInClient(conn)
+	if err != nil {
+		client.writeFailure(messagingSendFailure, []string{err.Error()})
+		return
+	}
+
+	content, ok := action.Payload["content"].(string)
+	if !ok {
+		client.writeFailure(messagingSendFailure, []string{"content is missing"})
+		return
+	}
+
+	messageGroupID, ok := action.Payload["message_group_id"].(float64)
+	if !ok {
+		client.writeFailure(messagingSendFailure, []string{"message_group_id is missing"})
+		return
+	}
+
+	senderID, ok := action.Payload["sender_id"].(float64)
+	if !ok {
+		client.writeFailure(messagingSendFailure, []string{"sender_id is missing"})
+		return
+	}
+
+	if client.ID != int(senderID) {
+		client.writeFailure(messagingSendFailure, []string{"sender_id mismatch"})
+		return
+	}
+
+	if !isClientInMessageGroup(int(senderID), int(messageGroupID)) {
+		client.writeFailure(messagingSendFailure, []string{"sender doesn't belong to message group"})
+		return
+	}
+
+	message, err := createMessage(content, int(messageGroupID), int(senderID))
+	if err != nil {
+		client.writeFailure(messagingSendFailure, []string{err.Error()})
+		return
+	}
+
+	payload := make(map[string]interface{})
+	payload["message_id"] = message.ID
+	client.writeJSON(&Action{
+		Payload: payload,
+		Type:    messagingSendSuccess,
+	})
 }
 
 func handleMessagingBroadcastRequest(conn *websocket.Conn, action *Action) {

--- a/v2.go
+++ b/v2.go
@@ -116,6 +116,20 @@ func handleMessagingSendRequest(conn *websocket.Conn, action *Action) {
 		return
 	}
 
+	messageGroupMemberIDs, err := findAllMessageGroupMemberIDs(message.MessageGroupID)
+	if err != nil {
+		client.writeFailure(messagingSendFailure, []string{err.Error()})
+		return
+	}
+
+	for _, recipientID := range messageGroupMemberIDs {
+		if recipientID == int(message.SenderID) {
+			continue
+		}
+
+		createReceipt(message.ID, recipientID)
+	}
+
 	payload := make(map[string]interface{})
 	payload["message_id"] = message.ID
 	client.writeJSON(&Action{

--- a/v2.go
+++ b/v2.go
@@ -175,7 +175,11 @@ func handleMessagingDeliverSuccess(conn *websocket.Conn, action *Action) {
 	}
 
 	recipientID := client.ID
-	updateReceiptDateDelivered(int(messageID), recipientID)
+	err = updateReceiptDateDelivered(int(messageID), recipientID)
+	if err != nil {
+		client.writeFailure(messagingDeliverFailure, []string{err.Error()})
+		return
+	}
 }
 
 func handleMessagingBroadcastRequest(conn *websocket.Conn, action *Action) {

--- a/v2.go
+++ b/v2.go
@@ -122,12 +122,23 @@ func handleMessagingSendRequest(conn *websocket.Conn, action *Action) {
 		return
 	}
 
+	var recipientIDs []int
+
 	for _, recipientID := range messageGroupMemberIDs {
 		if recipientID == int(message.SenderID) {
 			continue
 		}
 
+		recipientIDs = append(recipientIDs, recipientID)
+	}
+
+	for _, recipientID := range recipientIDs {
 		createReceipt(message.ID, recipientID)
+	}
+
+	messageDeliveryChan <- &MessageDelivery{
+		Message:      message,
+		RecipientIDs: recipientIDs,
 	}
 
 	payload := make(map[string]interface{})


### PR DESCRIPTION
#34

https://www.lucidchart.com/invitations/accept/06fb2086-c166-4d11-8146-6c1fba8eeeda

Changes:
- [x] Add ~`group`~ `message_group` table
  - Turns out `group` is a reserved keyword for MySQL lol
- [x] Add `message` table
- [x] Add `message_group_member` table
- [x] Add ~`message_pending_delivery` & `message_pending_receipt`~ `receipt` table
  - Both crossed out tables should be combined I think
  - WhatsApp ticks can be implemented by just adding more `date_xxx` columns
- [x] Support `MESSAGING_DELIVER_REQUEST`, ...
- [x] Support `MESSAGING_SEND_REQUEST`, ...