### PR TITLE
support add member into group

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1,0 +1,20 @@
+package main
+
+func createGroupAddMemberFailureAction(errors []string) *Action {
+	payload := make(map[string]interface{})
+	payload["errors"] = errors
+
+	return &Action{
+		Payload: payload,
+		Type:    groupAddMemberFailure,
+	}
+}
+
+func createGroupAddMemberSuccessAction() *Action {
+	payload := make(map[string]interface{})
+
+	return &Action{
+		Payload: payload,
+		Type:    groupAddMemberSuccess,
+	}
+}

--- a/actions.go
+++ b/actions.go
@@ -1,20 +1,36 @@
 package main
 
-func createGroupAddMemberFailureAction(errors []string) *Action {
+func createEmptyAction(actionType string) *Action {
+	payload := make(map[string]interface{})
+
+	return &Action{
+		Payload: payload,
+		Type:    actionType,
+	}
+}
+
+func createFailureAction(actionType string, errors []string) *Action {
 	payload := make(map[string]interface{})
 	payload["errors"] = errors
 
 	return &Action{
 		Payload: payload,
-		Type:    groupAddMemberFailure,
+		Type:    actionType,
 	}
 }
 
-func createGroupAddMemberSuccessAction() *Action {
-	payload := make(map[string]interface{})
+func createGroupAddMemberFailureAction(errors []string) *Action {
+	return createFailureAction(groupAddMemberFailure, errors)
+}
 
-	return &Action{
-		Payload: payload,
-		Type:    groupAddMemberSuccess,
-	}
+func createGroupAddMemberSuccessAction() *Action {
+	return createEmptyAction(groupAddMemberSuccess)
+}
+
+func createGroupLeaveFailureAction(errors []string) *Action {
+	return createFailureAction(groupLeaveFailure, errors)
+}
+
+func createGroupLeaveSuccessAction() *Action {
+	return createEmptyAction(groupLeaveSuccess)
 }

--- a/constants.go
+++ b/constants.go
@@ -5,6 +5,10 @@ const (
 	authorizationSignInRequest = "AUTHORIZATION_SIGN_IN_REQUEST"
 	authorizationSignInSuccess = "AUTHORIZATION_SIGN_IN_SUCCESS"
 
+	groupAddMemberFailure = "GROUP_ADD_MEMBER_FAILURE"
+	groupAddMemberRequest = "GROUP_ADD_MEMBER_REQUEST"
+	groupAddMemberSuccess = "GROUP_ADD_MEMBER_SUCCESS"
+
 	groupCreateFailure = "GROUP_CREATE_FAILURE"
 	groupCreateRequest = "GROUP_CREATE_REQUEST"
 	groupCreateSuccess = "GROUP_CREATE_SUCCESS"

--- a/constants.go
+++ b/constants.go
@@ -13,6 +13,10 @@ const (
 	groupCreateRequest = "GROUP_CREATE_REQUEST"
 	groupCreateSuccess = "GROUP_CREATE_SUCCESS"
 
+	groupLeaveFailure = "GROUP_LEAVE_FAILURE"
+	groupLeaveRequest = "GROUP_LEAVE_REQUEST"
+	groupLeaveSuccess = "GROUP_LEAVE_SUCCESS"
+
 	messagingDeliverFailure = "MESSAGING_DELIVER_FAILURE"
 	messagingDeliverRequest = "MESSAGING_DELIVER_REQUEST"
 	messagingDeliverSuccess = "MESSAGING_DELIVER_SUCCESS"

--- a/db.go
+++ b/db.go
@@ -258,6 +258,35 @@ func createReceipt(messageID, recipientID int) error {
 	return err
 }
 
+func deleteMessageGroupMembers(groupID int, memberIDs []int) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	delete, err := tx.Prepare(`
+		DELETE FROM message_group_member WHERE message_group_id = ? AND member_id = ?;
+	`)
+	if err != nil {
+		return err
+	}
+
+	for _, memberID := range memberIDs {
+		_, err := delete.Exec(groupID, memberID)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return nil
+}
+
 func getOrCreateClient(countryCode, phoneNumber string) (*Client, error) {
 	if countryCode != getDigits(countryCode) {
 		return nil, errors.New("country code should only contain digits")

--- a/db.go
+++ b/db.go
@@ -144,6 +144,112 @@ func createMessage(content string, messageGroupID, senderID int) (*Message, erro
 	}, nil
 }
 
+func createMessageGroup(groupName string, memberIDs []int) (*MessageGroup, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		logInfo(dbTag, "transaction error. "+err.Error())
+		return nil, err
+	}
+
+	result, err := tx.Exec(
+		`INSERT INTO message_group ( name ) VALUES ( ? );`,
+		groupName,
+	)
+	if err != nil {
+		tx.Rollback()
+		logInfo(dbTag, "error creating message group. "+err.Error())
+		return nil, err
+	}
+
+	groupID, err := result.LastInsertId()
+	if err != nil {
+		tx.Rollback()
+		logInfo(dbTag, "error creating message group. "+err.Error())
+		return nil, err
+	}
+
+	for _, memberID := range memberIDs {
+		result, err = tx.Exec(
+			`INSERT INTO message_group_member ( message_group_id, member_id )
+			VALUES ( ?, ? );`,
+			groupID,
+			memberID,
+		)
+		if err != nil {
+			tx.Rollback()
+			logInfo(
+				dbTag,
+				fmt.Sprintf("failed to create message group %v in db. %v", groupName, err.Error()),
+			)
+			return nil, err
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		logInfo(dbTag, "error committing transaction. "+err.Error())
+		return nil, err
+	}
+
+	rows, err := db.Query(
+		`SELECT date_created FROM message_group WHERE id = ?;`,
+		groupID,
+	)
+	if err != nil {
+		logInfo(dbTag, "error retrieving message group. "+err.Error())
+		return nil, err
+	}
+
+	if !rows.Next() {
+		errorMsg := "message_group `%v` has been added to the database but "
+		errorMsg += "an error occured when querying it"
+		logInfo(dbTag, fmt.Sprintf(errorMsg, groupName))
+		return nil, errors.New(errorMsg)
+	}
+
+	var dateCreated string
+	rows.Scan(&dateCreated)
+
+	messageGroup := &MessageGroup{
+		ID:          groupID,
+		Name:        groupName,
+		DateCreated: dateCreated,
+
+		MemberIDs: memberIDs,
+	}
+
+	return messageGroup, nil
+}
+
+func createMessageGroupMembers(messageGroupID int, memberIDs []int) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	insert, err := tx.Prepare(`
+		INSERT INTO message_group_member ( message_group_id, member_id )
+		VALUES ( ?, ? );
+	`)
+	if err != nil {
+		return err
+	}
+
+	for _, memberID := range memberIDs {
+		_, err := insert.Exec(messageGroupID, memberID)
+		if err != nil {
+			return tx.Rollback()
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func createReceipt(messageID, recipientID int) error {
 	_, err := db.Query(`
 		INSERT INTO receipt ( message_id, recipient_id ) VALUES ( ?, ? );
@@ -367,81 +473,4 @@ func updateReceiptDateDelivered(messageID, recipientID int) error {
 		WHERE message_id = ? AND recipient_id = ?;
 	`, messageID, recipientID)
 	return err
-}
-
-func createMessageGroup(groupName string, memberIDs []int) (*MessageGroup, error) {
-	tx, err := db.Begin()
-	if err != nil {
-		logInfo(dbTag, "transaction error. "+err.Error())
-		return nil, err
-	}
-
-	result, err := tx.Exec(
-		`INSERT INTO message_group ( name ) VALUES ( ? );`,
-		groupName,
-	)
-	if err != nil {
-		tx.Rollback()
-		logInfo(dbTag, "error creating message group. "+err.Error())
-		return nil, err
-	}
-
-	groupID, err := result.LastInsertId()
-	if err != nil {
-		tx.Rollback()
-		logInfo(dbTag, "error creating message group. "+err.Error())
-		return nil, err
-	}
-
-	for _, memberID := range memberIDs {
-		result, err = tx.Exec(
-			`INSERT INTO message_group_member ( message_group_id, member_id )
-			VALUES ( ?, ? );`,
-			groupID,
-			memberID,
-		)
-		if err != nil {
-			tx.Rollback()
-			logInfo(
-				dbTag,
-				fmt.Sprintf("failed to create message group %v in db. %v", groupName, err.Error()),
-			)
-			return nil, err
-		}
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		logInfo(dbTag, "error committing transaction. "+err.Error())
-		return nil, err
-	}
-
-	rows, err := db.Query(
-		`SELECT date_created FROM message_group WHERE id = ?;`,
-		groupID,
-	)
-	if err != nil {
-		logInfo(dbTag, "error retrieving message group. "+err.Error())
-		return nil, err
-	}
-
-	if !rows.Next() {
-		errorMsg := "message_group `%v` has been added to the database but "
-		errorMsg += "an error occured when querying it"
-		logInfo(dbTag, fmt.Sprintf(errorMsg, groupName))
-		return nil, errors.New(errorMsg)
-	}
-
-	var dateCreated string
-	rows.Scan(&dateCreated)
-
-	messageGroup := &MessageGroup{
-		ID:          groupID,
-		Name:        groupName,
-		DateCreated: dateCreated,
-
-		MemberIDs: memberIDs,
-	}
-
-	return messageGroup, nil
 }


### PR DESCRIPTION
Resolves #36 

As of now, when a new client is added to or removed from the message group, all other members are not notified. I think they should be notified of the update on the next message send request. This means for each message send or delivery we can either:
1. Always send message group info action
2. Check for message group membership change and send the action only when there's a difference

@imranariffin 