### PR TITLE
notify group creation to members

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,5 +1,7 @@
 package actions
 
+const actionsTag = "actions"
+
 // Action .
 type Action struct {
 	Payload map[string]interface{} `json:"payload"`

--- a/actions/group.go
+++ b/actions/group.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"github.com/hooligram/hooligram-server/constants"
 	"github.com/hooligram/hooligram-server/db"
+	"github.com/hooligram/hooligram-server/utils"
 )
 
 //////////////////////
@@ -29,7 +30,7 @@ func GroupCreateFailure(errors []string) *Action {
 }
 
 // GroupCreateSuccess .
-func GroupCreateSuccess(groupID int64) *Action {
+func GroupCreateSuccess(groupID int) *Action {
 	payload := make(map[string]interface{})
 	payload["message_group_id"] = groupID
 
@@ -44,11 +45,23 @@ func GroupCreateSuccess(groupID int64) *Action {
 ///////////////////
 
 // GroupDeliverRequest .
-func GroupDeliverRequest(messageGroup *db.MessageGroup) *Action {
+func GroupDeliverRequest(messageGroupID int) *Action {
+	messageGroup, err := db.ReadMessageGroupByID(messageGroupID)
+	if err != nil {
+		utils.LogInfo(actionsTag, "error reading message group by id. "+err.Error())
+		return &Action{}
+	}
+
+	memberIDs, err := messageGroup.MemberIDs()
+	if err != nil {
+		utils.LogInfo(actionsTag, "error getting message group member ids. "+err.Error())
+		return &Action{}
+	}
+
 	payload := make(map[string]interface{})
 	payload["date_created"] = messageGroup.DateCreated
 	payload["group_name"] = messageGroup.Name
-	payload["member_ids"] = messageGroup.MemberIDs
+	payload["member_ids"] = memberIDs
 	payload["message_group_id"] = messageGroup.ID
 
 	return &Action{

--- a/actions/group.go
+++ b/actions/group.go
@@ -56,6 +56,16 @@ func GroupDeliverRequest(messageGroup *db.MessageGroup) *Action {
 	}
 }
 
+// GroupDeliverSuccessFailure .
+func GroupDeliverSuccessFailure(errors []string) *Action {
+	return constructFailureAction(constants.GroupDeliverSuccessFailure, errors)
+}
+
+// GroupDeliverSuccessSuccess .
+func GroupDeliverSuccessSuccess() *Action {
+	return constructEmptyAction(constants.GroupDeliverSuccessSuccess)
+}
+
 /////////////////
 // GROUP_LEAVE //
 /////////////////

--- a/actions/group.go
+++ b/actions/group.go
@@ -1,6 +1,9 @@
 package actions
 
-import "github.com/hooligram/hooligram-server/constants"
+import (
+	"github.com/hooligram/hooligram-server/constants"
+	"github.com/hooligram/hooligram-server/db"
+)
 
 //////////////////////
 // GROUP_ADD_MEMBER //
@@ -33,6 +36,23 @@ func GroupCreateSuccess(groupID int64) *Action {
 	return &Action{
 		Payload: payload,
 		Type:    constants.GroupCreateSuccess,
+	}
+}
+
+///////////////////
+// GROUP_DELIVER //
+///////////////////
+
+// GroupDeliverRequest .
+func GroupDeliverRequest(messageGroup *db.MessageGroup) *Action {
+	payload := make(map[string]interface{})
+	payload["date_created"] = messageGroup.DateCreated
+	payload["group_name"] = messageGroup.Name
+	payload["message_group_id"] = messageGroup.ID
+
+	return &Action{
+		Payload: payload,
+		Type:    constants.GroupDeliverRequest,
 	}
 }
 

--- a/actions/group.go
+++ b/actions/group.go
@@ -48,6 +48,7 @@ func GroupDeliverRequest(messageGroup *db.MessageGroup) *Action {
 	payload := make(map[string]interface{})
 	payload["date_created"] = messageGroup.DateCreated
 	payload["group_name"] = messageGroup.Name
+	payload["member_ids"] = messageGroup.MemberIDs
 	payload["message_group_id"] = messageGroup.ID
 
 	return &Action{

--- a/actions/group.go
+++ b/actions/group.go
@@ -26,19 +26,9 @@ func GroupCreateFailure(errors []string) *Action {
 }
 
 // GroupCreateSuccess .
-func GroupCreateSuccess(
-	groupID int64,
-	groupName string,
-	memberIDs []int,
-	dateCreated string,
-) *Action {
+func GroupCreateSuccess(groupID int64) *Action {
 	payload := make(map[string]interface{})
-	memberIDs = append([]int(nil), memberIDs...)
-
-	payload["id"] = groupID
-	payload["date_created"] = dateCreated
-	payload["member_ids"] = memberIDs
-	payload["name"] = groupName
+	payload["message_group_id"] = groupID
 
 	return &Action{
 		Payload: payload,

--- a/actions/messaging.go
+++ b/actions/messaging.go
@@ -5,9 +5,9 @@ import (
 	"github.com/hooligram/hooligram-server/db"
 )
 
-//////////////////////////////
-// CREATE_MESSAGING_DELIVER //
-//////////////////////////////
+///////////////////////
+// MESSAGING_DELIVER //
+///////////////////////
 
 // MessagingDeliverRequest .
 func MessagingDeliverRequest(message *db.Message) *Action {
@@ -40,9 +40,9 @@ func MessagingDeliverSuccessSuccess(messageID int) *Action {
 	}
 }
 
-///////////////////////////
-// CREATE_MESSAGING_SEND //
-///////////////////////////
+////////////////////
+// MESSAGING_SEND //
+////////////////////
 
 // MessagingSendFailure .
 func MessagingSendFailure(errors []string) *Action {

--- a/clients/client.go
+++ b/clients/client.go
@@ -1,6 +1,8 @@
 package clients
 
 import (
+	"sync"
+
 	"github.com/gorilla/websocket"
 	"github.com/hooligram/hooligram-server/actions"
 	"github.com/hooligram/hooligram-server/db"
@@ -13,6 +15,7 @@ type Client struct {
 
 	id         int
 	isSignedIn bool
+	lock       sync.Mutex
 }
 
 // GetID .
@@ -116,5 +119,7 @@ func (client *Client) WriteFailure(actionType string, errors []string) {
 
 // WriteJSON .
 func (client *Client) WriteJSON(action *actions.Action) error {
+	client.lock.Lock()
+	defer client.lock.Unlock()
 	return client.Conn.WriteJSON(*action)
 }

--- a/constants/actiontypes.go
+++ b/constants/actiontypes.go
@@ -14,6 +14,12 @@ const (
 	GroupCreateRequest = "GROUP_CREATE_REQUEST"
 	GroupCreateSuccess = "GROUP_CREATE_SUCCESS"
 
+	GroupDeliverFailure        = "GROUP_DELIVER_FAILURE"
+	GroupDeliverRequest        = "GROUP_DELIVER_REQUEST"
+	GroupDeliverSuccess        = "GROUP_DELIVER_SUCCESS"
+	GroupDeliverSuccessFailure = "GROUP_DELIVER_SUCCESS_FAILURE"
+	GroupDeliverSuccessSuccess = "GROUP_DELIVER_SUCCESS_SUCCESS"
+
 	GroupLeaveFailure = "GROUP_LEAVE_FAILURE"
 	GroupLeaveRequest = "GROUP_LEAVE_REQUEST"
 	GroupLeaveSuccess = "GROUP_LEAVE_SUCCESS"

--- a/db/db.go
+++ b/db/db.go
@@ -118,8 +118,8 @@ func init() {
 	`)
 }
 
-// FindUndeliveredMessages .
-func FindUndeliveredMessages(recipientID int) ([]*Message, error) {
+// ReadUndeliveredMessages .
+func ReadUndeliveredMessages(recipientID int) ([]*Message, error) {
 	rows, err := instance.Query(`
 		SELECT message.*
 		FROM receipt JOIN message ON receipt.message_id = message.id

--- a/db/db.go
+++ b/db/db.go
@@ -118,6 +118,30 @@ func init() {
 	`)
 }
 
+// ReadClientMessageGroupIDs .
+func ReadClientMessageGroupIDs(clientID int) ([]int, error) {
+	rows, err := instance.Query(`
+		SELECT message_group.id
+		FROM message_group_member
+			JOIN message_group
+			ON message_group_member.message_group_id = message_group.id
+		WHERE message_group_member.member_id = ?;
+	`, clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	groupIDs := []int{}
+
+	for rows.Next() {
+		var groupID int
+		rows.Scan(&groupID)
+		groupIDs = append(groupIDs, groupID)
+	}
+
+	return groupIDs, nil
+}
+
 // ReadUndeliveredMessages .
 func ReadUndeliveredMessages(recipientID int) ([]*Message, error) {
 	rows, err := instance.Query(`

--- a/db/messagegroup.go
+++ b/db/messagegroup.go
@@ -39,7 +39,6 @@ func (messageGroup *MessageGroup) MemberIDs() ([]int, error) {
 func CreateMessageGroup(groupName string, memberIDs []int) (*MessageGroup, error) {
 	tx, err := instance.Begin()
 	if err != nil {
-		// utils.LogInfo(dbTag, "transaction error. "+err.Error())
 		return nil, err
 	}
 
@@ -49,14 +48,12 @@ func CreateMessageGroup(groupName string, memberIDs []int) (*MessageGroup, error
 	)
 	if err != nil {
 		tx.Rollback()
-		// utils.LogInfo(dbTag, "error creating message group. "+err.Error())
 		return nil, err
 	}
 
 	groupID, err := result.LastInsertId()
 	if err != nil {
 		tx.Rollback()
-		// utils.LogInfo(dbTag, "error creating message group. "+err.Error())
 		return nil, err
 	}
 
@@ -69,17 +66,12 @@ func CreateMessageGroup(groupName string, memberIDs []int) (*MessageGroup, error
 		)
 		if err != nil {
 			tx.Rollback()
-			// utils.LogInfo(
-			// 	dbTag,
-			// 	fmt.Sprintf("failed to create message group %v in instance. %v", groupName, err.Error()),
-			// )
 			return nil, err
 		}
 	}
 
 	err = tx.Commit()
 	if err != nil {
-		// utils.LogInfo(dbTag, "error committing transaction. "+err.Error())
 		return nil, err
 	}
 
@@ -88,14 +80,12 @@ func CreateMessageGroup(groupName string, memberIDs []int) (*MessageGroup, error
 		groupID,
 	)
 	if err != nil {
-		// utils.LogInfo(dbTag, "error retrieving message group. "+err.Error())
 		return nil, err
 	}
 
 	if !rows.Next() {
 		errorMsg := "message_group `%v` has been added to the database but "
 		errorMsg += "an error occured when querying it"
-		// utils.LogInfo(dbTag, fmt.Sprintf(errorMsg, groupName))
 		return nil, errors.New(errorMsg)
 	}
 

--- a/db/messagegroup.go
+++ b/db/messagegroup.go
@@ -101,36 +101,6 @@ func CreateMessageGroup(groupName string, memberIDs []int) (*MessageGroup, error
 	return messageGroup, nil
 }
 
-// CreateMessageGroupMembers .
-func CreateMessageGroupMembers(messageGroupID int, memberIDs []int) error {
-	tx, err := instance.Begin()
-	if err != nil {
-		return err
-	}
-
-	insert, err := tx.Prepare(`
-		INSERT INTO message_group_member ( message_group_id, member_id )
-		VALUES ( ?, ? );
-	`)
-	if err != nil {
-		return err
-	}
-
-	for _, memberID := range memberIDs {
-		_, err := insert.Exec(messageGroupID, memberID)
-		if err != nil {
-			return tx.Rollback()
-		}
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 //////////
 // READ //
 //////////
@@ -168,33 +138,3 @@ func ReadMessageGroupByID(id int) (*MessageGroup, error) {
 ////////////
 // DELETE //
 ////////////
-
-// DeleteMessageGroupMembers .
-func DeleteMessageGroupMembers(groupID int, memberIDs []int) error {
-	tx, err := instance.Begin()
-	if err != nil {
-		return err
-	}
-
-	delete, err := tx.Prepare(`
-		DELETE FROM message_group_member WHERE message_group_id = ? AND member_id = ?;
-	`)
-	if err != nil {
-		return err
-	}
-
-	for _, memberID := range memberIDs {
-		_, err := delete.Exec(groupID, memberID)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	return nil
-}

--- a/db/messagegroupmember.go
+++ b/db/messagegroupmember.go
@@ -1,5 +1,39 @@
 package db
 
+////////////
+// CREATE //
+////////////
+
+// CreateMessageGroupMembers .
+func CreateMessageGroupMembers(messageGroupID int, memberIDs []int) error {
+	tx, err := instance.Begin()
+	if err != nil {
+		return err
+	}
+
+	insert, err := tx.Prepare(`
+		INSERT INTO message_group_member ( message_group_id, member_id )
+		VALUES ( ?, ? );
+	`)
+	if err != nil {
+		return err
+	}
+
+	for _, memberID := range memberIDs {
+		_, err := insert.Exec(messageGroupID, memberID)
+		if err != nil {
+			return tx.Rollback()
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 //////////
 // READ //
 //////////
@@ -37,4 +71,42 @@ func ReadIsClientInMessageGroup(clientID, messageGroupID int) bool {
 	}
 
 	return rows.Next()
+}
+
+////////////
+// UPDATE //
+////////////
+
+////////////
+// DELETE //
+////////////
+
+// DeleteMessageGroupMembers .
+func DeleteMessageGroupMembers(groupID int, memberIDs []int) error {
+	tx, err := instance.Begin()
+	if err != nil {
+		return err
+	}
+
+	delete, err := tx.Prepare(`
+		DELETE FROM message_group_member WHERE message_group_id = ? AND member_id = ?;
+	`)
+	if err != nil {
+		return err
+	}
+
+	for _, memberID := range memberIDs {
+		_, err := delete.Exec(groupID, memberID)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return nil
 }

--- a/delivery/delivery.go
+++ b/delivery/delivery.go
@@ -54,7 +54,7 @@ func DeliverMessageGroup() {
 				continue
 			}
 
-			action := actions.GroupDeliverRequest(messageGroup)
+			action := actions.GroupDeliverRequest(messageGroup.ID)
 			client.WriteJSON(action)
 		}
 	}

--- a/delivery/delivery.go
+++ b/delivery/delivery.go
@@ -13,7 +13,16 @@ type MessageDelivery struct {
 	RecipientIDs []int
 }
 
-var messageDeliveryChan = make(chan *MessageDelivery)
+// MessageGroupDelivery .
+type MessageGroupDelivery struct {
+	MessageGroup *db.MessageGroup
+	RecipientIDs []int
+}
+
+var (
+	messageDeliveryChan      = make(chan *MessageDelivery)
+	messageGroupDeliveryChan = make(chan *MessageGroupDelivery)
+)
 
 // DeliverMessage .
 func DeliverMessage() {
@@ -33,7 +42,30 @@ func DeliverMessage() {
 	}
 }
 
+// DeliverMessageGroup .
+func DeliverMessageGroup() {
+	for {
+		messageGroupDelivery := <-GetMessageGroupDeliveryChan()
+		messageGroup := messageGroupDelivery.MessageGroup
+		recipientIDs := messageGroupDelivery.RecipientIDs
+
+		for _, client := range clients.GetSignedInClients() {
+			if !utils.ContainsID(recipientIDs, client.GetID()) {
+				continue
+			}
+
+			action := actions.GroupDeliverRequest(messageGroup)
+			client.WriteJSON(action)
+		}
+	}
+}
+
 // GetMessageDeliveryChan .
 func GetMessageDeliveryChan() chan *MessageDelivery {
 	return messageDeliveryChan
+}
+
+// GetMessageGroupDeliveryChan .
+func GetMessageGroupDeliveryChan() chan *MessageGroupDelivery {
+	return messageGroupDeliveryChan
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	router.HandleFunc("/v2", v2.V2)
 
 	go delivery.DeliverMessage()
+	go delivery.DeliverMessageGroup()
 
 	http.ListenAndServe(":"+port, router)
 }

--- a/v2/authorization.go
+++ b/v2/authorization.go
@@ -67,7 +67,7 @@ func handleAuthorizationSignInRequest(
 	success := actions.AuthorizationSignInSuccess()
 	client.WriteJSON(success)
 
-	undeliveredMessages, err := db.FindUndeliveredMessages(client.GetID())
+	undeliveredMessages, err := db.ReadUndeliveredMessages(client.GetID())
 	if err != nil {
 		utils.LogBody(v2Tag, "error finding messages to deliver. "+err.Error())
 	}

--- a/v2/authorization.go
+++ b/v2/authorization.go
@@ -72,6 +72,16 @@ func handleAuthorizationSignInRequest(
 		utils.LogBody(v2Tag, "error finding messages to deliver. "+err.Error())
 	}
 
+	messageGroupIDs, err := db.ReadClientMessageGroupIDs(client.GetID())
+	if err != nil {
+		utils.LogBody(v2Tag, "error reading client message group ids. "+err.Error())
+	}
+
+	for _, messageGroupID := range messageGroupIDs {
+		request := actions.GroupDeliverRequest(messageGroupID)
+		client.WriteJSON(request)
+	}
+
 	for _, undeliveredMessage := range undeliveredMessages {
 		action := actions.MessagingDeliverRequest(undeliveredMessage)
 		client.WriteJSON(action)

--- a/v2/group.go
+++ b/v2/group.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hooligram/hooligram-server/actions"
 	"github.com/hooligram/hooligram-server/clients"
 	"github.com/hooligram/hooligram-server/db"
+	"github.com/hooligram/hooligram-server/delivery"
 	"github.com/hooligram/hooligram-server/utils"
 )
 
@@ -87,6 +88,21 @@ func handleGroupCreateRequest(client *clients.Client, action *actions.Action) *a
 		failure := actions.GroupCreateFailure([]string{"server error"})
 		client.WriteJSON(failure)
 		return failure
+	}
+
+	recipientIDs := []int{}
+
+	for _, memberID := range memberIDs {
+		if memberID == client.GetID() {
+			continue
+		}
+
+		recipientIDs = append(recipientIDs, memberID)
+	}
+
+	delivery.GetMessageGroupDeliveryChan() <- &delivery.MessageGroupDelivery{
+		MessageGroup: messageGroup,
+		RecipientIDs: recipientIDs,
 	}
 
 	success := actions.GroupCreateSuccess(messageGroup.ID)

--- a/v2/group.go
+++ b/v2/group.go
@@ -18,14 +18,14 @@ func handleGroupAddMemberRequest(client *clients.Client, action *actions.Action)
 
 	groupID, ok := action.Payload["group_id"].(float64)
 	if !ok {
-		failure := actions.GroupAddMemberFailure([]string{"group_id is missing"})
+		failure := actions.GroupAddMemberFailure([]string{"group_id not in payload"})
 		client.WriteJSON(failure)
 		return failure
 	}
 
 	memberID, ok := action.Payload["member_id"].(float64)
 	if !ok {
-		failure := actions.GroupAddMemberFailure([]string{"member_id is missing"})
+		failure := actions.GroupAddMemberFailure([]string{"member_id not in payload"})
 		client.WriteJSON(failure)
 		return failure
 	}
@@ -110,6 +110,19 @@ func handleGroupCreateRequest(client *clients.Client, action *actions.Action) *a
 	return success
 }
 
+func handleGroupDeliverSuccess(client *clients.Client, action *actions.Action) *actions.Action {
+	_, ok := action.Payload["message_group_id"].(float64)
+	if !ok {
+		failure := actions.GroupDeliverSuccessFailure([]string{"message_group_id not in payload"})
+		client.WriteJSON(failure)
+		return failure
+	}
+
+	success := actions.GroupDeliverSuccessSuccess()
+	client.WriteJSON(success)
+	return success
+}
+
 func handleGroupLeaveRequest(client *clients.Client, action *actions.Action) *actions.Action {
 	if !client.IsSignedIn() {
 		utils.LogBody(v2Tag, "client not signed in")
@@ -120,7 +133,7 @@ func handleGroupLeaveRequest(client *clients.Client, action *actions.Action) *ac
 
 	groupID, ok := action.Payload["group_id"].(float64)
 	if !ok {
-		failure := actions.GroupLeaveFailure(([]string{"group_id is missing"}))
+		failure := actions.GroupLeaveFailure(([]string{"group_id not in payload"}))
 		client.WriteJSON(failure)
 		return failure
 	}

--- a/v2/group.go
+++ b/v2/group.go
@@ -49,9 +49,9 @@ func handleGroupAddMemberRequest(client *clients.Client, action *actions.Action)
 }
 
 func handleGroupCreateRequest(client *clients.Client, action *actions.Action) *actions.Action {
-	groupName, ok := action.Payload["name"].(string)
+	groupName, ok := action.Payload["group_name"].(string)
 	if !ok {
-		failure := actions.GroupCreateFailure([]string{"name not in payload"})
+		failure := actions.GroupCreateFailure([]string{"group_name not in payload"})
 		client.WriteJSON(failure)
 		return failure
 	}
@@ -89,12 +89,7 @@ func handleGroupCreateRequest(client *clients.Client, action *actions.Action) *a
 		return failure
 	}
 
-	success := actions.GroupCreateSuccess(
-		messageGroup.ID,
-		messageGroup.Name,
-		messageGroup.MemberIDs,
-		messageGroup.DateCreated,
-	)
+	success := actions.GroupCreateSuccess(messageGroup.ID)
 	client.WriteJSON(success)
 	return success
 }

--- a/v2/messaging.go
+++ b/v2/messaging.go
@@ -87,7 +87,7 @@ func handleMessagingSendRequest(client *clients.Client, action *actions.Action) 
 func handleMessagingDeliverSuccess(client *clients.Client, action *actions.Action) *actions.Action {
 	messageID, ok := action.Payload["message_id"].(float64)
 	if !ok {
-		failure := actions.MessagingDeliverSuccessFailure([]string{"message_id is missing"})
+		failure := actions.MessagingDeliverSuccessFailure([]string{"message_id not in payload"})
 		client.WriteJSON(failure)
 		return failure
 	}

--- a/v2/v2.go
+++ b/v2/v2.go
@@ -82,6 +82,8 @@ func V2(w http.ResponseWriter, r *http.Request) {
 			result = handleGroupAddMemberRequest(client, &action)
 		case constants.GroupCreateRequest:
 			result = handleGroupCreateRequest(client, &action)
+		case constants.GroupDeliverSuccess:
+			result = handleGroupDeliverSuccess(client, &action)
 		case constants.GroupLeaveRequest:
 			result = handleGroupLeaveRequest(client, &action)
 		case constants.MessagingSendRequest:


### PR DESCRIPTION
Resolve #54, #55 

Changes:
- Send `GROUP_DELIVER_REQUEST` to online members
- Send `GROUP_DELIVER_REQUEST` everytime clients sign in
  - This will allow clients to update their group messages after a period of being offline
  - Will send the update regardless of any changes to the group membership to simplify stuff
- Propagate group member addition & removal via message group delivery